### PR TITLE
Resolve syntax errors with the examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - tests/*.go
       - tests/*/*.go
+      - tests/*/*/*.go
       - okta/*.go
       - okta/*/*.go
       - okta/*/*/*.go

--- a/okta/api/client.go
+++ b/okta/api/client.go
@@ -348,7 +348,7 @@ func (o *Okta) ListAppMembers(appId string) ([]OktaUser, error) {
 	resultsPerPage := 500
 	restClient := o.GetRestClient()
 
-	url := fmt.Sprintf("/api/v1/apps/%s/users?limit=%s", appId, resultsPerPage)
+	url := fmt.Sprintf("/api/v1/apps/%s/users?limit=%d", appId, resultsPerPage)
 	req := restClient.R().SetBody("").SetResult([]OktaUser{})
 
 	resp, err := req.Get(url)

--- a/okta/api/provisioning.go
+++ b/okta/api/provisioning.go
@@ -34,7 +34,7 @@ func doRequest(client http.Client, request *http.Request) (*http.Response, error
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return resp, fmt.Errorf("Provisioning did not yield successful %s", resp.StatusCode)
+		return resp, fmt.Errorf("Provisioning did not yield successful %d", resp.StatusCode)
 	}
 
 	return resp, nil

--- a/tests/members/add/main.go
+++ b/tests/members/add/main.go
@@ -33,6 +33,6 @@ func main() {
 	result, _ := client.ListAppMembers(appId)
 	for _, element := range result {
 		fmt.Println("ID:\n", element.ID)
-		fmt.Println("Username:\n", element.Credentials.UserName)
+		fmt.Println("Username:\n", element.Profile.Email)
 	}
 }

--- a/tests/members/all/main.go
+++ b/tests/members/all/main.go
@@ -23,6 +23,6 @@ func main() {
 	result, _ := client.ListAppMembers(appId)
 	for _, element := range result {
 		fmt.Println("ID:\n", element.ID)
-		fmt.Println("Username:\n", element.Credentials.UserName)
+		fmt.Println("Username:\n", element.Profile.Email)
 	}
 }

--- a/tests/members/remove/main.go
+++ b/tests/members/remove/main.go
@@ -30,6 +30,6 @@ func main() {
 	result, _ := client.ListAppMembers(appId)
 	for _, element := range result {
 		fmt.Println("ID:\n", element.ID)
-		fmt.Println("Username:\n", element.Credentials.UserName)
+		fmt.Println("Username:\n", element.Profile.Email)
 	}
 }


### PR DESCRIPTION
When development work for some of the refactoring was finishing, GitHub Actions was disabled for a short period. This meant that some things that would have been caught by CI got through (format mistakes + invalid usages in examples).

This PR resolves format mistakes and ensures that the examples are up to date.