### PR TITLE
Fix printing of error response from Okta

### DIFF
--- a/okta/api/client.go
+++ b/okta/api/client.go
@@ -259,10 +259,10 @@ func (okta *Okta) SetRestClient(rest *resty.Client) {
 			rateLimit, err := strconv.Atoi(r.Header().Get("x-rate-limit-remaining"))
 
 			if err == nil && rateLimit <= 0 {
-				return fmt.Errorf(`Response not succesful, rate limit exceeded: Recieved status code %d. Response %s`, status, r.Result())
+				return fmt.Errorf(`Response not succesful, rate limit exceeded: Recieved status code %d. Response %s`, status, r.String())
 			}
 
-			return fmt.Errorf(`Response not successful: Received status code %d. Response: %s`, status, r.Result())
+			return fmt.Errorf(`Response not successful: Received status code %d. Response: %s`, status, r.String())
 		}
 
 		return nil


### PR DESCRIPTION
Fixes: `Error: Response not successful: Received status code 400. Response: &{ <nil> <nil> <nil> <nil> <nil> <nil> { []}}`


Was looking at Resty and realized this wasn't the behavior when it had an empty response, it was instead an error on my part WRT how I tried to log the error response.